### PR TITLE
fix: getbookingId to return in array format to be same as getBooking

### DIFF
--- a/handler/booking_handler.go
+++ b/handler/booking_handler.go
@@ -142,7 +142,7 @@ func GetBookingIdHandler(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, booking)
+	c.JSON(http.StatusOK, []dto.Booking{booking})
 	return
 }
 


### PR DESCRIPTION
Objective
I want to use the same decoding way in payment MFE for /booking and booking/:id. Fix to return in array format for both

<img width="1090" alt="image" src="https://github.com/NUS-EVCHARGE/ev-booking-service/assets/10574652/a3d26d59-a9ae-4364-94ea-85fcf56d958f">

I should had combine /booking/:id with /booking together, then i will not this issue from the start. 